### PR TITLE
feat: add discord bot skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Discord Bot
+
+This is a basic multi-server Discord bot built with Node.js and `discord.js`. It includes:
+
+- Per-server prefix stored in SQLite
+- Ticket system
+- Admin commands (kick/ban)
+- Giveaways
+- Welcome messages
+- Feedback system
+- Temporary voice channels
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a bot in the [Discord Developer Portal](https://discord.com/developers/applications) and copy its token.
+3. Set the environment variable `DISCORD_TOKEN` to the bot token.
+4. Start the bot:
+   ```bash
+   npm start
+   ```
+
+Commands can be prefixed with the configured server prefix (default `!`).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bot",
+  "version": "1.0.0",
+  "description": "Multi-server Discord bot with tickets, admin, giveaways, welcomes, feedback, and temp voice channels.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "echo \"No tests defined\" && exit 1"
+  },
+  "keywords": ["discord", "bot"],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.13.0",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'ban',
+  description: 'Ban a member',
+  async execute({ message }) {
+    if (!message.member.permissions.has('BanMembers')) {
+      return message.reply('You need Ban Members permission.');
+    }
+    const member = message.mentions.members.first();
+    if (!member) return message.reply('Mention a user to ban.');
+    await member.ban();
+    message.reply(`Banned ${member.user.tag}`);
+  }
+};

--- a/src/commands/feedback.js
+++ b/src/commands/feedback.js
@@ -1,0 +1,14 @@
+module.exports = {
+  name: 'feedback',
+  description: 'Send feedback to configured channel',
+  async execute({ message, args, db }) {
+    const content = args.join(' ');
+    if (!content) return message.reply('Provide feedback content.');
+    const config = await db.getGuild(message.guild.id);
+    if (!config.feedback_channel) return message.reply('Feedback channel not set.');
+    const channel = message.guild.channels.cache.get(config.feedback_channel);
+    if (!channel) return message.reply('Feedback channel not found.');
+    channel.send(`Feedback from ${message.author}:\n${content}`);
+    message.reply('Feedback sent.');
+  }
+};

--- a/src/commands/giveaway.js
+++ b/src/commands/giveaway.js
@@ -1,0 +1,29 @@
+const { EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  name: 'giveaway',
+  description: 'Start a giveaway',
+  async execute({ message, args }) {
+    const duration = parseInt(args.shift(), 10);
+    const prize = args.join(' ');
+    if (!duration || !prize) {
+      return message.reply('Usage: giveaway <seconds> <prize>');
+    }
+    const embed = new EmbedBuilder()
+      .setTitle('Giveaway')
+      .setDescription(`Prize: ${prize}\nReact with 🎉 to enter!\nEnds in ${duration}s`)
+      .setColor('Gold');
+    const giveawayMessage = await message.channel.send({ embeds: [embed] });
+    await giveawayMessage.react('🎉');
+    setTimeout(async () => {
+      const fetched = await giveawayMessage.fetch();
+      const reaction = fetched.reactions.cache.get('🎉');
+      if (!reaction) return message.channel.send('No participants.');
+      const users = await reaction.users.fetch();
+      const entrants = users.filter(u => !u.bot);
+      const winner = entrants.random();
+      if (winner) message.channel.send(`Congratulations ${winner} you won **${prize}**!`);
+      else message.channel.send('No valid participants.');
+    }, duration * 1000);
+  }
+};

--- a/src/commands/kick.js
+++ b/src/commands/kick.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'kick',
+  description: 'Kick a member',
+  async execute({ message }) {
+    if (!message.member.permissions.has('KickMembers')) {
+      return message.reply('You need Kick Members permission.');
+    }
+    const member = message.mentions.members.first();
+    if (!member) return message.reply('Mention a user to kick.');
+    await member.kick();
+    message.reply(`Kicked ${member.user.tag}`);
+  }
+};

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'ping',
+  description: 'Simple ping command',
+  async execute({ message }) {
+    await message.reply('Pong!');
+  }
+};

--- a/src/commands/setfeedback.js
+++ b/src/commands/setfeedback.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'setfeedback',
+  description: 'Set feedback channel',
+  async execute({ message, args, db }) {
+    if (!message.member.permissions.has('Administrator')) {
+      return message.reply('You need administrator permission.');
+    }
+    const channel = message.mentions.channels.first();
+    if (!channel) return message.reply('Mention a channel.');
+    db.setFeedbackChannel(message.guild.id, channel.id);
+    message.reply(`Feedback channel set to ${channel}`);
+  }
+};

--- a/src/commands/setprefix.js
+++ b/src/commands/setprefix.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'setprefix',
+  description: 'Set custom prefix for this server',
+  async execute({ message, args, db }) {
+    if (!message.member.permissions.has('Administrator')) {
+      return message.reply('You need administrator permission.');
+    }
+    const prefix = args[0];
+    if (!prefix) return message.reply('Provide a prefix.');
+    db.setPrefix(message.guild.id, prefix);
+    message.reply(`Prefix set to \`${prefix}\``);
+  }
+};

--- a/src/commands/setwelcome.js
+++ b/src/commands/setwelcome.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'setwelcome',
+  description: 'Set welcome channel',
+  async execute({ message, args, db }) {
+    if (!message.member.permissions.has('Administrator')) {
+      return message.reply('You need administrator permission.');
+    }
+    const channel = message.mentions.channels.first();
+    if (!channel) return message.reply('Mention a channel.');
+    db.setWelcomeChannel(message.guild.id, channel.id);
+    message.reply(`Welcome channel set to ${channel}`);
+  }
+};

--- a/src/commands/ticket.js
+++ b/src/commands/ticket.js
@@ -1,0 +1,16 @@
+module.exports = {
+  name: 'ticket',
+  description: 'Create a private support ticket',
+  async execute({ message }) {
+    const channel = await message.guild.channels.create({
+      name: `ticket-${message.author.id}`,
+      type: 0,
+      permissionOverwrites: [
+        { id: message.guild.id, deny: ['ViewChannel'] },
+        { id: message.author.id, allow: ['ViewChannel', 'SendMessages'] },
+        { id: message.client.user.id, allow: ['ViewChannel', 'SendMessages'] }
+      ]
+    });
+    message.reply(`Ticket created: ${channel}`);
+  }
+};

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,46 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.resolve(__dirname, '../data.sqlite'));
+
+// Initialize tables
+const init = () => {
+  db.run(`CREATE TABLE IF NOT EXISTS guilds (
+      id TEXT PRIMARY KEY,
+      prefix TEXT DEFAULT '!',
+      welcome_channel TEXT,
+      feedback_channel TEXT
+    )`);
+};
+
+init();
+
+module.exports = {
+  getGuild(id) {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT * FROM guilds WHERE id = ?', [id], (err, row) => {
+        if (err) return reject(err);
+        if (!row) return resolve({ id, prefix: '!' });
+        resolve(row);
+      });
+    });
+  },
+  setPrefix(id, prefix) {
+    db.run(
+      'INSERT INTO guilds(id, prefix) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET prefix=excluded.prefix',
+      [id, prefix]
+    );
+  },
+  setWelcomeChannel(id, channelId) {
+    db.run(
+      'INSERT INTO guilds(id, welcome_channel) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET welcome_channel=excluded.welcome_channel',
+      [id, channelId]
+    );
+  },
+  setFeedbackChannel(id, channelId) {
+    db.run(
+      'INSERT INTO guilds(id, feedback_channel) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET feedback_channel=excluded.feedback_channel',
+      [id, channelId]
+    );
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,74 @@
+const { Client, GatewayIntentBits, Partials, Collection, EmbedBuilder } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildVoiceStates,
+    GatewayIntentBits.GuildMessageReactions
+  ],
+  partials: [Partials.Message, Partials.Channel, Partials.Reaction]
+});
+
+client.commands = new Collection();
+const commandsPath = path.join(__dirname, 'commands');
+for (const file of fs.readdirSync(commandsPath)) {
+  const command = require(path.join(commandsPath, file));
+  client.commands.set(command.name, command);
+}
+
+client.once('ready', () => {
+  console.log(`Logged in as ${client.user.tag}`);
+});
+
+client.on('guildMemberAdd', async member => {
+  const guildConfig = await db.getGuild(member.guild.id);
+  if (!guildConfig.welcome_channel) return;
+  const channel = member.guild.channels.cache.get(guildConfig.welcome_channel);
+  if (!channel) return;
+  const embed = new EmbedBuilder()
+    .setTitle('Welcome!')
+    .setDescription(`Welcome to the server, ${member}!`)
+    .setColor('Green');
+  channel.send({ embeds: [embed] });
+});
+
+client.on('messageCreate', async message => {
+  if (message.author.bot || !message.guild) return;
+  const guildConfig = await db.getGuild(message.guild.id);
+  const prefix = guildConfig.prefix || '!';
+  if (!message.content.startsWith(prefix)) return;
+  const args = message.content.slice(prefix.length).trim().split(/\s+/);
+  const commandName = args.shift().toLowerCase();
+  const command = client.commands.get(commandName);
+  if (!command) return;
+  try {
+    await command.execute({ client, message, args, db });
+  } catch (err) {
+    console.error(err);
+    message.reply('There was an error executing that command.');
+  }
+});
+
+client.on('voiceStateUpdate', async (oldState, newState) => {
+  if (!newState.channel || newState.channel.name !== 'Create') return;
+  const channel = await newState.guild.channels.create({
+    name: `Temp ${newState.member.user.username}`,
+    type: 2,
+    parent: newState.channel.parent
+  });
+  await newState.setChannel(channel);
+  const checkEmpty = setInterval(async () => {
+    if (channel.members.size === 0) {
+      clearInterval(checkEmpty);
+      channel.delete().catch(() => {});
+    }
+  }, 30000);
+});
+
+client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- add Node.js Discord bot framework with per-server settings stored in SQLite
- include commands for prefix, tickets, admin tools, giveaways, feedback, and welcomes
- handle temporary voice channels

## Testing
- `npm test` *(fails: No tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a53fa6f90c832a804c5e7ce03d1d06